### PR TITLE
use_mongo_id and use_collection defined in the connection configuration

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -651,7 +651,12 @@ abstract class Model extends BaseModel
      */
     public function useMongoId()
     {
-        return (bool) config('database.connections.mongodb.use_mongo_id', false);
+        if (function_exists('config')) {
+            return (bool) config('database.connections.mongodb.use_mongo_id', false);
+        }
+
+        $connection = $this->getConnection();
+        return $connection->getConfig('use_mongo_id');
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -119,6 +119,9 @@ class Builder extends BaseBuilder
             $version = app()->version();
             $version = filter_var(explode(')', $version)[0], FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION); // lumen
             return version_compare($version, '5.3', '>=');
+        } else {
+            $connection = $this->getConnection();
+            return $connection->getConfig('use_collection');
         }
     }
 


### PR DESCRIPTION

Was integrating the Moloquent with the Slim 3, the framework does not exist the "config" of laravel. With this implementation configuration can be set from a configuration file or through the "config" of laravel.

The keys "use_mongo_id" and "use_collection" are Boolean.