### PR TITLE
Update Builder.php

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -62,7 +62,7 @@ class Builder extends BaseBuilder
      *
      * @var array
      */
-    protected $operators = [
+    public $operators = [
         '=', '<', '>', '<=', '>=', '<>', '!=',
         'like', 'not like', 'between', 'ilike',
         '&', '|', '^', '<<', '>>',


### PR DESCRIPTION
change access specifier on $operators property to match Laravel base 

[Symfony\Component\Debug\Exception\FatalErrorException]                                                             
  Access level to Moloquent\Query\Builder::$operators must be public (as in class Illuminate\Database\Query\Builder)