### PR TITLE
Solved belongsToMany exceptions

### DIFF
--- a/src/Eloquent/HybridRelations.php
+++ b/src/Eloquent/HybridRelations.php
@@ -231,7 +231,8 @@ trait HybridRelations
         // name of the calling function. We will use that function name as the
         // title of this relation since that is a great convention to apply.
         if (is_null($relation)) {
-            $relation = $this->guessBelongsToManyRelation();
+            list($one, $two, $caller) = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+            $relation = $caller["function"];
         }
 
         // Check if it is a relation with an original model.

--- a/src/Eloquent/HybridRelations.php
+++ b/src/Eloquent/HybridRelations.php
@@ -231,7 +231,7 @@ trait HybridRelations
         // name of the calling function. We will use that function name as the
         // title of this relation since that is a great convention to apply.
         if (is_null($relation)) {
-            $relation = $this->getBelongsToManyCaller();
+            $relation = $this->guessBelongsToManyRelation();
         }
 
         // Check if it is a relation with an original model.

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -198,7 +198,7 @@ class BelongsToMany extends EloquentBelongsToMany
         }
 
         // Attach the new ids to the parent model.
-        $this->parent->push($this->otherKey, (array) $id, true);
+        $this->parent->push($this->foreignKey, (array) $id, true);
 
         if ($touch) {
             $this->touchIfTouching();


### PR DESCRIPTION
The `BelongsToMany` relation threw a few exceptions,  for example `Call to undefined method Moloquent\Query\Builder::getBelongsToManyCaller()` and one about the `$otherKey` variable in the `attach()` function. Both of these are now working for me.`