### PR TITLE
Many to Many relation maintenance.

### DIFF
--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -29,6 +29,14 @@ class BelongsToMany extends EloquentBelongsToMany
     {
         return $columns;
     }
+	
+	/**
+     * @inheritdoc
+     */
+    protected function shouldSelect(array $columns = ['*'])
+    {
+        return $columns;
+    }
 
     /**
      * Set the base constraints on the relation query.


### PR DESCRIPTION
Fixed `belongsToMany` relation to fix query of attributes while getting the related models (See #58).