### PR TITLE
Gets key name from model rather than assuming _id

### DIFF
--- a/src/Relations/EmbedsMany.php
+++ b/src/Relations/EmbedsMany.php
@@ -251,8 +251,8 @@ class EmbedsMany extends EmbedsOneOrMany
     protected function associateNew($model)
     {
         // Create a new key if needed.
-        if (!$model->getAttribute('_id')) {
-            $model->setAttribute('_id', new ObjectID());
+        if (!$model->getKey()) {
+            $model->setAttribute($model->getKeyName(), new ObjectID());
         }
 
         $records = $this->getEmbedded();


### PR DESCRIPTION
I need to work with some old documents where embedded documents have a key named something other than `_id` - this change prevents `associateNew()` from adding additional `_id` attributes to the embedded documents.