### PR TITLE
Update HybridRelations.php

### DIFF
--- a/src/Eloquent/HybridRelations.php
+++ b/src/Eloquent/HybridRelations.php
@@ -217,15 +217,18 @@ trait HybridRelations
     /**
      * Define a many-to-many relationship.
      *
-     * @param string $related
-     * @param string $collection
-     * @param string $foreignKey
-     * @param string $otherKey
-     * @param string $relation
+     * @param  string  $related
+     * @param  string  $table
+     * @param  string  $foreignPivotKey
+     * @param  string  $relatedPivotKey
+     * @param  string  $parentKey
+     * @param  string  $relatedKey
+     * @param  string  $relation
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
-    public function belongsToMany($related, $collection = null, $foreignKey = null, $otherKey = null, $relation = null)
+    public function belongsToMany($related, $table = null, $foreignPivotKey = null, $relatedPivotKey = null,
+    $parentKey = null, $relatedKey = null, $relation = null)
     {
         // If no relationship name was passed, we will pull backtraces to get the
         // name of the calling function. We will use that function name as the
@@ -242,7 +245,8 @@ trait HybridRelations
 
         // Check if it is a relation with an original model.
         if (!is_subclass_of($related, 'Moloquent\Eloquent\Model')) {
-            return parent::belongsToMany($related, $collection, $foreignKey, $otherKey, $relation);
+            return parent::belongsToMany($related, $table = null, $foreignPivotKey = null, $relatedPivotKey = null,
+            $parentKey = null, $relatedKey = null, $relation = null);
         }
 
         // First, we'll need to determine the foreign key and "other key" for the
@@ -266,6 +270,7 @@ trait HybridRelations
         // appropriate query constraint and entirely manages the hydrations.
         $query = $instance->newQuery();
 
-        return new BelongsToMany($query, $this, $collection, $foreignKey, $otherKey, $relation);
+        return new BelongsToMany($related, $table = null, $foreignPivotKey = null, $relatedPivotKey = null,
+        $parentKey = null, $relatedKey = null, $relation = null);
     }
 }


### PR DESCRIPTION
**Error with new official released Laravel 5.5**

Declaration of Moloquent\Eloquent\HybridRelations::belongsToMany($related, $collection = NULL, $foreignKey = NULL, $otherKey = NULL, $relation = NULL) should be compatible with Illuminate\Database\Eloquent\Model::belongsToMany($related, $table = NULL, $foreignPivotKey = NULL, $relatedPivotKey = NULL, $parentKey = NULL, $relatedKey = NULL, $relation = NULL)

update to laravel 5.5

[issue #82](https://github.com/moloquent/moloquent/issues/82)