### PR TITLE
Fixes getting relationship by using camelKey instead of key

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -263,7 +263,7 @@ abstract class Model extends BaseModel
                     }
 
                     // Get the relation results.
-                    return $this->getRelationshipFromMethod($key, $camelKey);
+                    return $this->getRelationshipFromMethod($camelKey);
                 }
 
                 if ($relations instanceof Relation) {
@@ -275,7 +275,7 @@ abstract class Model extends BaseModel
                     }
 
                     // Get the relation results.
-                    return $this->getRelationshipFromMethod($key, $camelKey);
+                    return $this->getRelationshipFromMethod($camelKey);
                 }
             }
         }


### PR DESCRIPTION
The `getRelationshipFromMethod()` method only takes a single argument, which should be the camel case version of the key. This fixes an issue with underscore-separated key names, where the function would attempt to call `$this->key_name()` rather than `$this->keyName()`

I noticed that the jenssegers version of the getAttribute() method was trimmed down in https://github.com/jenssegers/laravel-mongodb/commit/140f28ea91859f83a50a7f1fb2f818306423e509 so it may be worth updating the Moloquent version to match; I'm less familiar with other changes that may have been made in this method so have left it as-is for now. 