### PR TITLE
getDateFormat() must be public

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -196,7 +196,7 @@ abstract class Model extends BaseModel
      *
      * @return string
      */
-    protected function getDateFormat()
+    public function getDateFormat()
     {
         return $this->dateFormat ?: 'Y-m-d H:i:s';
     }


### PR DESCRIPTION
Access level to Moloquent\Eloquent\Model::getDateFormat() must be public (as in class Illuminate\Database\Eloquent\Model)