### PR TITLE
correção de alguns erros que o pacote apresentou pós instalação.

### DIFF
--- a/src/Eloquent/HybridRelations.php
+++ b/src/Eloquent/HybridRelations.php
@@ -178,7 +178,7 @@ trait HybridRelations
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
-    public function morphTo($name = null, $type = null, $id = null)
+    public function morphTo($name = null, $type = null, $id = null, $ownerKey = null)
     {
         // If no name is provided, we will use the backtrace to get the function name
         // since that is most likely the name of the polymorphic interface. We can

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -196,7 +196,7 @@ abstract class Model extends BaseModel
      *
      * @return string
      */
-    protected function getDateFormat()
+    public function getDateFormat()
     {
         return $this->dateFormat ?: 'Y-m-d H:i:s';
     }


### PR DESCRIPTION
Correção para erros:

> Access level to Moloquent\Eloquent\Model::getDateFormat() must be public (as in class Illuminate\Database\Eloquent\Model)

e

> Declaration of Moloquent\Eloquent\HybridRelations::morphTo($name = NULL, $type = NULL, $id = NULL) should be compatible with Illuminate\Database\Eloquent\Model::morphTo($name = NULL, $typ  
  e = NULL, $id = NULL, $ownerKey = NULL)